### PR TITLE
Fix notype for single byte types

### DIFF
--- a/src/libraries/notype/cat/notype
+++ b/src/libraries/notype/cat/notype
@@ -15,7 +15,7 @@ class no_type {
 
    constexpr no_type(auto input)
       requires(sizeof(input) == 1)
-       : m_q_storage(__builtin_bit_cast(unsigned char, input)) {
+       : m_b_storage(__builtin_bit_cast(unsigned char, input)) {
    }
 
    constexpr no_type(auto input)


### PR DESCRIPTION
The `no_type` constructor for single byte types was using the 4-byte storage instead of the 1-byte storage, which seemed like a mistake.