### PR TITLE
Constrain maybe::assign to types with has_value()/value()

### DIFF
--- a/src/libraries/arithmetic/cat/arithmetic
+++ b/src/libraries/arithmetic/cat/arithmetic
@@ -625,12 +625,10 @@ struct arithmetic :
                              / static_cast<promoted_raw>(raw_operand));
       } else if constexpr (overflow_policy == wrap
                            || overflow_policy == wrap_member) {
-         // TODO: This looks wrong.
-         return wrap_mul(raw, raw_operand);
+         return wrap_div(raw, raw_operand);
       } else if constexpr (overflow_policy == saturate
                            || overflow_policy == saturate_member) {
-         // TODO: This looks wrong.
-         return sat_mul(raw, raw_operand);
+         return sat_div(raw, raw_operand);
       }
    }
 

--- a/src/libraries/compare/cat/compare
+++ b/src/libraries/compare/cat/compare
@@ -554,7 +554,7 @@ using std::weak_ordering;
 
 template <typename T>
 concept is_common_comparison_category =
-   is_same<T, strong_ordering> && is_same<T, weak_ordering>
-   && is_same<T, partial_ordering>;
+   is_same<T, strong_ordering> || is_same<T, weak_ordering>
+   || is_same<T, partial_ordering>;
 
 }  // namespace cat

--- a/src/libraries/maybe/cat/maybe
+++ b/src/libraries/maybe/cat/maybe
@@ -202,9 +202,6 @@ struct maybe_value_storage {
 
    constexpr void
    assign(value_type const& maybe) {
-      if (__builtin_addressof(m_storage) == __builtin_addressof(maybe)) {
-         return;
-      }
       if (this->has_value()) {
          this->hard_reset();
       }
@@ -214,9 +211,6 @@ struct maybe_value_storage {
 
    constexpr void
    assign(value_type&& maybe) {
-      if (__builtin_addressof(m_storage) == __builtin_addressof(maybe)) {
-         return;
-      }
       if (this->has_value()) {
          this->hard_reset();
       }

--- a/src/libraries/maybe/cat/maybe
+++ b/src/libraries/maybe/cat/maybe
@@ -204,6 +204,9 @@ struct maybe_value_storage {
 
    constexpr void
    assign(value_type const& maybe) {
+      if (__builtin_addressof(m_storage) == __builtin_addressof(maybe)) {
+         return;
+      }
       if (this->has_value()) {
          this->hard_reset();
       }
@@ -213,6 +216,9 @@ struct maybe_value_storage {
 
    constexpr void
    assign(value_type&& maybe) {
+      if (__builtin_addressof(m_storage) == __builtin_addressof(maybe)) {
+         return;
+      }
       if (this->has_value()) {
          this->hard_reset();
       }

--- a/src/libraries/maybe/cat/maybe
+++ b/src/libraries/maybe/cat/maybe
@@ -223,6 +223,7 @@ struct maybe_value_storage {
    // If this is assigned an `maybe` which wraps a type that can be
    // converted to `T` , then convert that storage to this type implicitly.
    template <typename other_maybe>
+      requires requires(other_maybe m) { m.has_value(); m.value(); }
    constexpr void
    assign(other_maybe&& maybe) {
       if (maybe.has_value()) {
@@ -299,6 +300,7 @@ struct maybe_reference_storage {
    // If this is assigned an `maybe` which wraps a type that can be
    // converted to `T` , then convert that storage to this type implicitly.
    template <typename other_maybe>
+      requires requires(other_maybe m) { m.has_value(); m.value(); }
    constexpr void
    assign(other_maybe&& maybe) {
       if (this->has_value()) {
@@ -476,6 +478,7 @@ struct maybe_compact_storage {
    // If this is assigned an `maybe` which wraps a type that can be
    // converted to `T` , then convert that storage to this type implicitly.
    template <typename other_maybe>
+      requires requires(other_maybe m) { m.has_value(); m.value(); }
    constexpr void
    assign(other_maybe&& maybe) {
       if (this->has_value()) {


### PR DESCRIPTION
## Summary

Four bugs found via clang-tidy 23 (trunk) analysis:

### 1. Constrain `maybe::assign` template (commit 1)
- Add `requires` clause to all three `assign` template overloads
- The unconstrained template accepted any type including plain `int`, causing compilation errors
- Fixes #5, #6

### 2. Fix `is_common_comparison_category` concept (commit 2)
- Changed `&&` to `||` — the concept was always false since no type can simultaneously be `strong_ordering`, `weak_ordering`, AND `partial_ordering`
- This made `lexicographical_compare_three_way` uncallable

### 3. Fix `maybe_value_storage::assign` self-assignment (commit 2)
- `hard_reset()` destroyed `m_storage` before the assignment read from the `maybe` parameter
- If `maybe` aliased `m_storage`, this was use-after-destroy
- Added `__builtin_addressof` guard

### 4. Fix `divide_by` calling wrong functions (commit 2)
- Wrap/saturate branches called `wrap_mul`/`sat_mul` instead of `wrap_div`/`sat_div`
- Author-acknowledged with "TODO: This looks wrong"

## Build verification
- Clean 594/594 build with Clang 23.0.0git (llvm-project main, d7eec97bd83f)
- PCH disabled (-DCAT_PCH=OFF)

Fixes #5, #6